### PR TITLE
Better support items containing unicode strings

### DIFF
--- a/scrapy/logformatter.py
+++ b/scrapy/logformatter.py
@@ -5,9 +5,9 @@ from twisted.python.failure import Failure
 
 from scrapy.utils.request import referer_str
 
-SCRAPEDMSG = u"Scraped from %(src)s" + os.linesep + "%(item)s"
-DROPPEDMSG = u"Dropped: %(exception)s" + os.linesep + "%(item)s"
-CRAWLEDMSG = u"Crawled (%(status)s) %(request)s (referer: %(referer)s)%(flags)s"
+SCRAPEDMSG = "Scraped from %(src)s" + os.linesep + "%(item)s"
+DROPPEDMSG = "Dropped: %(exception)s" + os.linesep + "%(item)s"
+CRAWLEDMSG = "Crawled (%(status)s) %(request)s (referer: %(referer)s)%(flags)s"
 
 
 class LogFormatter(object):


### PR DESCRIPTION
The logformatter is firing a UnicodeDecodeError exception if one of the item objects contains 'extended' unicode 'chars'  i.e. éçàè... The logger does not complain if the u"" qualifier is not present in it's formating string!
